### PR TITLE
Support error chaining

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -38,9 +38,9 @@ var _ interface { // Assert interface implementation.
 // Chain returns a new error with its own message, annotated with a stack trace, wrapping the causing error. Chain
 // errors' messages do not (usually) contain the "%w" verb, as they are meant to be printed as a whole chain (e.g. in
 // a server request log).
-func Chain(message string, cause error) error {
+func Chain(cause error, message string, args ...interface{}) error {
 	return &chain{
-		message: message,
+		message: fmt.Sprintf(message, args...),
 		cause:   cause,
 		frames:  getStack(3),
 	}

--- a/chain.go
+++ b/chain.go
@@ -1,0 +1,95 @@
+package errors
+
+// Attribution: portions of the below code and documentation are modeled
+// directly on the https://pkg.go.dev/golang.org/x/xerrors library, used
+// with the permission available under the software license
+// (BSD 3-Clause):
+// https://cs.opensource.google/go/x/xerrors/+/master:LICENSE
+//
+// Attribution: portions of the below code and documentation are modeled
+// directly on the https://github.com/pkg/errors library, used
+// with the permission available under the software license
+// (BSD 2-Clause):
+// https://github.com/pkg/errors/blob/master/LICENSE
+
+import (
+	"fmt"
+	"io"
+)
+
+// Chain error wrapper.
+
+// chain implements an error participating in a chain of errors. This is different from a list of errors by having
+// each participating error having its own message, stack trace, and optionally a wrapped (causing) error.
+type chain struct {
+	message string
+	cause   error
+	frames  frames
+}
+
+var _ interface { // Assert interface implementation.
+	error
+	stackTracer
+	framer
+	Unwrap() error
+	fmt.Formatter
+} = (*chain)(nil)
+
+// Chain returns a new error with its own message, annotated with a stack trace, wrapping the causing error. Chain
+// errors' messages do not (usually) contain the "%w" verb, as they are meant to be printed as a whole chain (e.g. in
+// a server request log).
+func Chain(message string, cause error) error {
+	return &chain{
+		message: message,
+		cause:   cause,
+		frames:  getStack(3),
+	}
+}
+
+func (w *chain) Error() string { return w.message }
+
+func (w *chain) Unwrap() error { return w.cause }
+
+// StackTrace returns the call stack frames associated with this error
+// in the form of program counters; for examples of this see
+// https://pkg.go.dev/runtime or
+// https://pkg.go.dev/github.com/pkg/errors#Frame, both of which use the
+// uintptr type to represent program counters
+//
+// This method only returns the frames associated with the stack trace on
+// *this specific error* in the error chain. This interface is provided to
+// ease interoperability with error packages or APIs that expect stack
+// traces to be represented with uintptrs: Prefer the Frames method for
+// general interoperability across this package.
+func (w *chain) StackTrace() []uintptr { return w.frames.StackTrace() }
+
+// Frames returns the call stack frames associated with this error.
+//
+// This method only returns the frames associated with the stack trace
+// on *this specific error* in the error chain. Use FramesFrom to get
+// all the Frames associated with an error chain.
+func (w *chain) Frames() Frames { return w.frames.Frames() }
+
+func (w *chain) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			_, _ = fmt.Fprintf(s, "%s%+5v", w.message, w.Frames())
+			if w.cause != nil {
+				_, _ = fmt.Fprintf(s, "\n\nCAUSED BY: %+5v", w.cause)
+			}
+			return
+		}
+		if s.Flag('#') {
+			_, _ = fmt.Fprintf(s, "&errors.chain{%q %q}", w.message, w.cause)
+			return
+		}
+		fallthrough
+	case 's':
+		_, _ = io.WriteString(s, w.Error())
+	case 'q':
+		_, _ = fmt.Fprintf(s, "%q", w.Error())
+	default:
+		// empty
+	}
+}

--- a/chain_test.go
+++ b/chain_test.go
@@ -1,0 +1,76 @@
+package errors_test
+
+import (
+	"fmt"
+	"github.com/secureworks/errors"
+	"io"
+	"os"
+)
+
+func openCustomerFile(customerID string) (*os.File, error) {
+	f, err := os.Open("/data/customers/" + customerID + ".csv")
+	if err != nil {
+		return nil, errors.Chain("failed to open customer file", err)
+	}
+	return f, nil
+}
+
+func readCustomerInfo(customerID string) (string, error) {
+	f, err := openCustomerFile(customerID)
+	if err != nil {
+		return "", errors.Chain("failed to open customer", err)
+	}
+	defer f.Close()
+
+	bytes, err := io.ReadAll(f)
+	if err != nil {
+		return "", errors.Chain("failed to read customer info", err)
+	}
+	return string(bytes), nil
+}
+
+func Example() {
+	info, err := readCustomerInfo("arik")
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stdout, "%+v", err)
+	}
+	_, _ = fmt.Fprintf(os.Stdout, info)
+
+	// Output:
+	// failed to open customer
+	//      github.com/secureworks/errors_test.readCustomerInfo
+	//      	/Users/arikkfir/Development/github.com/arik-kfir/errors/chain_test.go:21
+	//      github.com/secureworks/errors_test.Example
+	//      	/Users/arikkfir/Development/github.com/arik-kfir/errors/chain_test.go:33
+	//      testing.runExample
+	//      	/opt/homebrew/opt/go/libexec/src/testing/run_example.go:63
+	//      testing.runExamples
+	//      	/opt/homebrew/opt/go/libexec/src/testing/example.go:44
+	//      testing.(*M).Run
+	//      	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1908
+	//      main.main
+	//      	_testmain.go:221
+	//      runtime.main
+	//      	/opt/homebrew/opt/go/libexec/src/runtime/proc.go:250
+	//
+	// CAUSED BY: failed to open customer file
+	//      github.com/secureworks/errors_test.openCustomerFile
+	//      	/Users/arikkfir/Development/github.com/arik-kfir/errors/chain_test.go:13
+	//      github.com/secureworks/errors_test.readCustomerInfo
+	//      	/Users/arikkfir/Development/github.com/arik-kfir/errors/chain_test.go:19
+	//      github.com/secureworks/errors_test.Example
+	//      	/Users/arikkfir/Development/github.com/arik-kfir/errors/chain_test.go:33
+	//      testing.runExample
+	//      	/opt/homebrew/opt/go/libexec/src/testing/run_example.go:63
+	//      testing.runExamples
+	//      	/opt/homebrew/opt/go/libexec/src/testing/example.go:44
+	//      testing.(*M).Run
+	//      	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1908
+	//      main.main
+	//      	_testmain.go:221
+	//      runtime.main
+	//      	/opt/homebrew/opt/go/libexec/src/runtime/proc.go:250
+	//
+	// CAUSED BY: open /data/customers/arik.csv: no such file or directory
+	//
+}

--- a/chain_test.go
+++ b/chain_test.go
@@ -10,7 +10,7 @@ import (
 func openCustomerFile(customerID string) (*os.File, error) {
 	f, err := os.Open("/data/customers/" + customerID + ".csv")
 	if err != nil {
-		return nil, errors.Chain("failed to open customer file", err)
+		return nil, errors.Chain(err, "failed to open customer file")
 	}
 	return f, nil
 }
@@ -18,13 +18,13 @@ func openCustomerFile(customerID string) (*os.File, error) {
 func readCustomerInfo(customerID string) (string, error) {
 	f, err := openCustomerFile(customerID)
 	if err != nil {
-		return "", errors.Chain("failed to open customer", err)
+		return "", errors.Chain(err, "failed to open customer")
 	}
 	defer f.Close()
 
 	bytes, err := io.ReadAll(f)
 	if err != nil {
-		return "", errors.Chain("failed to read customer info", err)
+		return "", errors.Chain(err, "failed to read customer info")
 	}
 	return string(bytes), nil
 }

--- a/frames.go
+++ b/frames.go
@@ -32,26 +32,25 @@ import (
 // Frames are meant to be seen, so we have implemented the following
 // default formatting verbs on it:
 //
-//     "%s"  – the base name of the file (or `unknown`) and the line number (if known)
-//     "%q"  – the same as `%s` but wrapped in `"` delimiters
-//     "%d"  – the line number
-//     "%n"  – the basic function name, ie without a full package qualifier
-//     "%v"  – the full path of the file (or `unknown`) and the line number (if known)
-//     "%+v" – a standard line in a stack trace: a full function name on one line,
-//             and a full file name and line number on a second line
-//     "%#v" – a Golang representation with the type (`errors.Frame`)
+//	"%s"  – the base name of the file (or `unknown`) and the line number (if known)
+//	"%q"  – the same as `%s` but wrapped in `"` delimiters
+//	"%d"  – the line number
+//	"%n"  – the basic function name, ie without a full package qualifier
+//	"%v"  – the full path of the file (or `unknown`) and the line number (if known)
+//	"%+v" – a standard line in a stack trace: a full function name on one line,
+//	        and a full file name and line number on a second line
+//	"%#v" – a Golang representation with the type (`errors.Frame`)
 //
 // Marshaling a frame as text uses the `%+v` format.
 // Marshaling as JSON returns an object with location data:
 //
-//     {"function":"test.pkg.in/example.init","file":"/src/example.go","line":10}
+//	{"function":"test.pkg.in/example.init","file":"/src/example.go","line":10}
 //
 // A Frame is immutable, so no setters are provided, but you can copy
 // one trivially with:
 //
-//     function, file, line := oldFrame.Location()
-//     newFrame := errors.NewFrame(function, file, line)
-//
+//	function, file, line := oldFrame.Location()
+//	newFrame := errors.NewFrame(function, file, line)
 type Frame interface {
 	// Location returns the frame's caller's characteristics for help with
 	// identifying and debugging the codebase.
@@ -140,8 +139,14 @@ func (f *frame) Format(s fmt.State, verb rune) {
 	case 'v':
 		switch {
 		case s.Flag('+'):
+			prefix := ""
+			width, ok := s.Width()
+			if ok {
+				prefix = strings.Repeat(" ", width)
+			}
+			io.WriteString(s, prefix)
 			io.WriteString(s, escaper.Replace(function))
-			io.WriteString(s, "\n\t")
+			io.WriteString(s, "\n"+prefix+"\t")
 			io.WriteString(s, escaper.Replace(file))
 			io.WriteString(s, ":")
 			io.WriteString(s, strconv.Itoa(line))
@@ -399,7 +404,6 @@ type framer interface {
 // item types are assignable to one another.
 //
 // See: https://github.com/getsentry/sentry-go/blob/v0.12.0/stacktrace.go#L81
-//
 type stackTracer interface {
 	StackTrace() []uintptr
 }


### PR DESCRIPTION
This PR adds an alternative error chaining method, which provides a cause & wrapper model. This chain is similar to the standard error wrapping chain (and in fact builds on top of it) but has the following differences:

- each error in the chain has its own message, and does not (and for our purposes, shouldn't) use the `%w` formatting flag
- innermost error is the "root" cause
- each item is a "causing error" (or simply: "cause") for the next error in the chain, i.e. the "caller" or "wrapper"
  - e.g. `could not load customer` → `file "customer-17.csv" not found`
  - the innermost error ("file ... not found") is the root error, and "causes" the caller to return a "could not load customer" wrapping error
- when error is `printf`'ed with `%+v` flag, for every error in the chain, starting from the outermost wrapper until the root error, the message & stack-trace is printed.
  - this provides a full context of not just what the root cause is, but exactly which code path was employed to generate it

See `chain_test.go` for a package example.

Here's a full example:
```go
package main

import (
	"fmt"
	"github.com/secureworks/errors"
	"io"
	"os"
)

func openCustomerFile(customerID string) (*os.File, error) {
	f, err := os.Open("/data/customers/" + customerID + ".csv")
	if err != nil {
		return nil, errors.Chain("failed to open customer file", err)
	}
	return f, nil
}

func readCustomerInfo(customerID string) (string, error) {
	f, err := openCustomerFile(customerID)
	if err != nil {
		return "", errors.Chain("failed to read customer info", err)
	}
	defer f.Close()

	bytes, err := io.ReadAll(f)
	if err != nil {
		return "", errors.Chain("failed to read customer info", err)
	}
	return string(bytes), nil
}

func main() {
	info, err := readCustomerInfo("my_cust_id")
	if err != nil {
		_, _ = fmt.Fprintf(os.Stderr, "%+v", err)
	}
	_, _ = fmt.Fprintf(os.Stdout, info)
}
```

Running this would yield this output:

```shell
$ go run main.go
failed to read customer info
     main.readCustomerInfo
        <local_directory_omited>/errors/cli/main.go:21
     main.main
        <local_directory_omited>/errors/cli/main.go:33
     runtime.main
        /opt/homebrew/opt/go/libexec/src/runtime/proc.go:250

CAUSED BY: failed to open customer file
     main.openCustomerFile
        <local_directory_omited>/errors/cli/main.go:13
     main.readCustomerInfo
        <local_directory_omited>/errors/cli/main.go:19
     main.main
        <local_directory_omited>/errors/cli/main.go:33
     runtime.main
        /opt/homebrew/opt/go/libexec/src/runtime/proc.go:250

CAUSED BY: open /data/customers/my_cust_id.csv: no such file or directory
```