### PR TITLE
Reformat with Go > 1.18

### DIFF
--- a/callers.go
+++ b/callers.go
@@ -41,8 +41,7 @@ func CallStackAt(skipCallers int) Frames {
 // (if the entire stack is less than maxFrames, the entireStack is
 // returned). maxFrames of zero or fewer is ignored:
 //
-//     CallStackAtMost(0, 0) // ... returns the entire stack for the caller
-//
+//	CallStackAtMost(0, 0) // ... returns the entire stack for the caller
 func CallStackAtMost(skipCallers int, maxFrames int) Frames {
 	st := getStack(skipCallers + 3)
 	stackLen := len(st)

--- a/frames.go
+++ b/frames.go
@@ -32,26 +32,25 @@ import (
 // Frames are meant to be seen, so we have implemented the following
 // default formatting verbs on it:
 //
-//     "%s"  – the base name of the file (or `unknown`) and the line number (if known)
-//     "%q"  – the same as `%s` but wrapped in `"` delimiters
-//     "%d"  – the line number
-//     "%n"  – the basic function name, ie without a full package qualifier
-//     "%v"  – the full path of the file (or `unknown`) and the line number (if known)
-//     "%+v" – a standard line in a stack trace: a full function name on one line,
-//             and a full file name and line number on a second line
-//     "%#v" – a Golang representation with the type (`errors.Frame`)
+//	"%s"  – the base name of the file (or `unknown`) and the line number (if known)
+//	"%q"  – the same as `%s` but wrapped in `"` delimiters
+//	"%d"  – the line number
+//	"%n"  – the basic function name, ie without a full package qualifier
+//	"%v"  – the full path of the file (or `unknown`) and the line number (if known)
+//	"%+v" – a standard line in a stack trace: a full function name on one line,
+//	        and a full file name and line number on a second line
+//	"%#v" – a Golang representation with the type (`errors.Frame`)
 //
 // Marshaling a frame as text uses the `%+v` format.
 // Marshaling as JSON returns an object with location data:
 //
-//     {"function":"test.pkg.in/example.init","file":"/src/example.go","line":10}
+//	{"function":"test.pkg.in/example.init","file":"/src/example.go","line":10}
 //
 // A Frame is immutable, so no setters are provided, but you can copy
 // one trivially with:
 //
-//     function, file, line := oldFrame.Location()
-//     newFrame := errors.NewFrame(function, file, line)
-//
+//	function, file, line := oldFrame.Location()
+//	newFrame := errors.NewFrame(function, file, line)
 type Frame interface {
 	// Location returns the frame's caller's characteristics for help with
 	// identifying and debugging the codebase.
@@ -399,7 +398,6 @@ type framer interface {
 // item types are assignable to one another.
 //
 // See: https://github.com/getsentry/sentry-go/blob/v0.12.0/stacktrace.go#L81
-//
 type stackTracer interface {
 	StackTrace() []uintptr
 }

--- a/internal/constraints/constraints.go
+++ b/internal/constraints/constraints.go
@@ -1,7 +1,6 @@
 // Package constraints should only be used as a blank import. When
 // imported it will cause `go build` to fail with an obvious and clean
 // message if the constraints defined in the package are not met.
-//
 package constraints
 
 var (

--- a/syncerr/docs.go
+++ b/syncerr/docs.go
@@ -10,16 +10,16 @@
 //
 // All tasks have the signature:
 //
-//     type task func() error
+//	type task func() error
 //
 // All groups share the interface:
 //
-//     type taskGroup interface {
-//         Go(func() error, ...string)
-//         Wait() error
-//     }
+//	type taskGroup interface {
+//	    Go(func() error, ...string)
+//	    Wait() error
+//	}
 //
-// CoordinatedGroup
+// # CoordinatedGroup
 //
 // If you want the tasks to run until at least one task returns an
 // error, and receive the first error as the outcome, use
@@ -29,37 +29,36 @@
 // > In fact, the taskGroup interface is implemented by
 // > "golang.org/x/sync/errgroup".
 //
-//     group, ctx := errors.NewCoordinatedGroup(ctx)
-//     group.Go(taskRunner, "task", "1")
-//     // ...
-//     if err := group.Wait(); err != nil {
-//         // ...
-//     }
+//	group, ctx := errors.NewCoordinatedGroup(ctx)
+//	group.Go(taskRunner, "task", "1")
+//	// ...
+//	if err := group.Wait(); err != nil {
+//	    // ...
+//	}
 //
 // The more terse, default version of the task runner returns a
 // CoordinatedGroup:
 //
-//     group, ctx := errors.NewGroup(ctx) // Same as errors.NewCoordinatedGroup.
+//	group, ctx := errors.NewGroup(ctx) // Same as errors.NewCoordinatedGroup.
 //
-// ParallelGroup
+// # ParallelGroup
 //
 // If you want all tasks to run to completion and have their errors
 // coalesced, use ParallelGroup:
 //
-//     group := new(errors.ParallelGroup)
-//     group.Go(taskRunner, "task", "1")
-//     // ...
-//     err := group.Wait()
-//     merr, _ := err.(*errors.MultiError)
-//     fmt.Println(merr.Errors())
+//	group := new(errors.ParallelGroup)
+//	group.Go(taskRunner, "task", "1")
+//	// ...
+//	err := group.Wait()
+//	merr, _ := err.(*errors.MultiError)
+//	fmt.Println(merr.Errors())
 //
 // ParallelGroup includes the function WaitForMultiError that skips the
 // step of asserting the multierror interface on the result:
 //
-//     group := new(errors.ParallelGroup)
-//     group.Go(taskRunner, "task", "1")
-//     // ...
-//     merr := group.WaitForMultiError()
-//     fmt.Println(merr.Errors())
-//
+//	group := new(errors.ParallelGroup)
+//	group.Go(taskRunner, "task", "1")
+//	// ...
+//	merr := group.WaitForMultiError()
+//	fmt.Println(merr.Errors())
 package syncerr // "github.com/secureworks/errors/syncerr"


### PR DESCRIPTION
Run `gofmt -s` with Go version > 1.19.