### PR TITLE
Rewrite MultiError logic to mirror decisions made in standard library

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,45 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.17
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: go mod download
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.42.0
+        config: .golangci.yaml

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.x
+    - name: Set up Go 1.20
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.17
+        go-version: ^1.20
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -14,10 +14,8 @@ hand.
 Important among these primitives are stack traces, explicit error collection
 types (multierrors and error groups) and error context management.
 
-While Go 1.13 introduced error wrapping utilities that have fixed some
-immediate issues, and Go 1.20 added a (very) minimal recognition that we may
-want to collect errors into a multierror, it is really useful to have a few
-more tools on hand.
+While Go 1.13 introduced error wrapping utilities and Go 1.20 added a minimal
+multierror collection, it is really useful to have a few more tools on hand.
 
 ### Installation
 
@@ -64,8 +62,8 @@ Package `github.com/secureworks/errors`:
 - use in place of the standard library with no change in behavior;
 - use the `errors.MultiError` type as either an explicit multierror 
   implementation or as an implicit multierror passed around with the default 
-  `error` interface; use `errors.Append` and others to simplify multierror 
-  management in your code;
+  `error` interface; use `errors.Join`, `errors.Append` and others to simplify
+  multierror management in your code;
 - embed (singular) stack frames with `errors.NewWithFrame("...")`, 
   `errors.WithFrame(err)`, and `fmt.Errorf("...: %w", err)`;
 - embed stack traces with `errors.NewWithStackTrace("...")` and
@@ -87,8 +85,6 @@ Package `github.com/secureworks/errors/syncerr`:
 Possible improvements before reaching `v1.0` include:
 
 - **Add support for Windows filepaths in call frames.**
-- Add direct integrations with other errors packages (especially those listed 
-  in the codebase).
 - Include either a linter or a suggested [`golang-ci`][golang-ci] lint YAML 
   to support idiomatic use.
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,32 @@
 # Errors
 
 This package provides a suite of tools meant to work with Go 1.13 error 
-wrapping to give users all the basics to handle errors in a useful way.
+wrapping and Go 1.20 multierrors. These helpers allow users to rely on
+standard Go error patterns while they include some "missing pieces" or
+additional features that are useful in practice.
 
 > _Another errors package? Why does Go need all of these error libraries?_
 
 Because the language and the standard library have a minimal approach to error 
 handling that leaves out some primitives power users expect to have on 
-hand. 
+hand.
 
-Important among these primitives are stack traces, error collections 
-(multi-errors and error groups) and error types. While Go 1.13 introduced 
-error wrapping utilities that have fixed some immediate issues, it is really 
-useful to have a few more tools on hand.
+Important among these primitives are stack traces, explicit error collection
+types (multierrors and error groups) and error context management.
+
+While Go 1.13 introduced error wrapping utilities that have fixed some
+immediate issues, and Go 1.20 added a (very) minimal recognition that we may
+want to collect errors into a multierror, it is really useful to have a few
+more tools on hand.
 
 ### Installation
 
 > _This package **may not be used** in environments:_
 >
-> 1. &nbsp; _running Go 1.12 or lower;_
+> 1. &nbsp; _running Go 1.19 or lower;_
 > 2. &nbsp; _running on 32-bit architecture;_
 > 3. &nbsp; _running on Windows (**currently** not supported)._
 
-Given that we are running on Go 1.13, your project should be using Go modules. 
 Add the following to your file:
 
 ```go
@@ -32,9 +36,21 @@ import "github.com/secureworks/errors"
 Then, when you run any Go command the toolchain will resolve and fetch the 
 required modules automatically.
 
+> If you are using Go 1.13 to Go 1.19, you should use the previous version of 
+> this library, which has the same functionality but does not support the 
+> specific form that Go 1.20 multierrors take:
+>
+> ```
+> $ go get github.com/secureworks/errors@v0.1.2
+> ```
+
 Because this package re-exports the package-level functions of the standard 
 library `"errors"` package, you do not need to include that package as well to 
-get `New`, `As`, `Is`, or `Unwrap`.
+get `New`, `As`, `Is`, `Unwrap`, and `Join`.
+
+Note that `Join` is a special case: for consistency, and since our multierror is
+a better implementation, `Join` returns our implementation (which uses our
+formatting), not the standard library's implementation.
 
 ### Use
 

--- a/docs.go
+++ b/docs.go
@@ -309,7 +309,7 @@
 //		PC() uintptr // Ie "programCounter," the interface for getting a frame's program counter.
 //
 //		// Used to identify an error that coalesces multiple errors:
-//		Errors() []error // Ie "multiError," the interface for getting multiple merged errors.
+//		Unwrap() []error // Ie "multierror," the interface for getting multiple merged errors.
 //	}
 //
 // Though none of these are exported by this package, they are

--- a/docs.go
+++ b/docs.go
@@ -26,7 +26,7 @@
 //		return fmt.Errorf("contextual information: %w", err)
 //	}
 //
-// This helps us identify a root causs and place that cause in some
+// This helps us identify a root cause, and place that cause in some
 // program context recursively.
 //
 // However, we are not always in control of the full extent of our
@@ -45,17 +45,14 @@
 //
 // 2. to chain or group errors and extract their contextual information;
 //
-// 3. to format errors with all oftheir context when printing them; and
+// 3. to format errors with all of their context when printing them; and
 //
 // 4. to retain a simple API for most use cases while retaining the
 // ability to directly interact with, or tune, error chains and groups.
 //
 // # Error wrapping in Go 1.13
 //
-// This errors package is meant to be used in addition to the updates in
-// https://go.dev/blog/go1.13-errors. Therefore, you shouldn't include
-// it (and in fact it will cause your build to fail) if you are using Go
-// 1.12 or earlier.
+// This package is meant to be used with [error wrapping].
 //
 // Importantly: this package does not attempt to replace this system.
 // Instead, errors is meant to enrich it: all the types and interfaces
@@ -67,6 +64,11 @@
 //	import "github.com/secureworks/errors"
 //
 //	var Err = errors.New("example err") // Same as if we had used: import "errors"
+//
+// # Wrapping multiple errors in Go 1.20
+//
+// This package is meant to be used with the [multiple error wrapping]
+// support introduced in Go 1.20.
 //
 // # Stack traces or call frames
 //
@@ -174,7 +176,7 @@
 //	}
 //
 //	if merr := actionWrapper(); merr != nil {
-//		fmt.Printf("%+v\n", merr.Errors())
+//		fmt.Printf("%+v\n", merr.Unwrap())
 //	}
 //
 // # Retrieving error information
@@ -268,11 +270,11 @@
 // and can be formatted by the fmt package. The following verbs are
 // supported:
 //
-//	%s    print the error's message context. Frames are not included in
-//	      the message.
-//	%v    see %s
-//	%+v   extended format. Each Frame of the error's Frames will
-//	      be printed in detail.
+//	%s  print the error's message context. Frames are not included in
+//	    the message.
+//	%v  see %s
+//	%+v extended format. Each Frame of the error's Frames will
+//	    be printed in detail.
 //
 // This not an exhaustive list, see the tests for more.
 //
@@ -312,4 +314,7 @@
 //
 // Though none of these are exported by this package, they are
 // considered a part of its stable public interface.
+//
+// [error wrapping]: https://blog.golang.org/go1.13-errors
+// [multiple error wrapping]: https://tip.golang.org/doc/go1.20#errors
 package errors

--- a/errors.go
+++ b/errors.go
@@ -16,7 +16,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"regexp"
 )
 
 // Stack trace error wrapper.
@@ -180,30 +179,6 @@ func WithFrames(err error, ff Frames) error {
 	return &withFrames{
 		error:  err,
 		frames: fframes,
-	}
-}
-
-var errorfFormatMatcher = regexp.MustCompile(`%(\[\d+])?w`)
-
-// Errorf is a shorthand for:
-//
-//	errors.WithFrame(fmt.Errorf("some msg: %w", err))
-//
-// It is made available to support the best practice of adding a call
-// stack frame to the error context alongside a message when building a
-// chain. When possible, prefer using the full syntax instead of this
-// shorthand for clarity.
-//
-// Using an invalid format string (one that does not wrap the given
-// error) causes this method to panic.
-func Errorf(format string, values ...interface{}) error {
-	if !errorfFormatMatcher.MatchString(format) {
-		panic(NewWithStackTrace(fmt.Sprintf("invalid use of errors.Errorf: "+
-			"format string must wrap an error, but \"%%w\" not found: %q", format)))
-	}
-	return &withFrames{
-		error:  fmt.Errorf(format, values...),
-		frames: frames{getFrame(3)},
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -359,7 +359,7 @@ func Opaque(err error) error {
 // Currently, this only supports single errors with or without a stack
 // trace or appended frames.
 //
-// TODO(PH): ensure ErrorFromBytes works with: multiError.
+// TODO(PH): ensure ErrorFromBytes works with: multierror.
 func ErrorFromBytes(byt []byte) (err error, ok bool) {
 	trimbyt := bytes.TrimRight(byt, "\n")
 	if len(trimbyt) == 0 || bytes.Equal(trimbyt, []byte("nil")) || bytes.Equal(trimbyt, []byte("<nil>")) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -417,24 +417,19 @@ func TestErrorStackTrace(t *testing.T) {
 func TestNilInputs(t *testing.T) {
 	t.Run("WithFrame", func(t *testing.T) {
 		testutils.AssertTrue(t, WithFrame(nil) == nil)
-		testutils.AssertTrue(t, WithFrame((*errorType)(nil)) == nil)
 	})
 	t.Run("WithFrameAt", func(t *testing.T) {
 		testutils.AssertTrue(t, WithFrameAt(nil, 4) == nil)
-		testutils.AssertTrue(t, WithFrameAt((*errorType)(nil), 4) == nil)
 	})
 	t.Run("WithFrames", func(t *testing.T) {
 		ff := Frames{}
 		testutils.AssertTrue(t, WithFrames(nil, ff) == nil)
-		testutils.AssertTrue(t, WithFrames((*errorType)(nil), ff) == nil)
 	})
 	t.Run("WithStackTrace", func(t *testing.T) {
 		testutils.AssertTrue(t, WithStackTrace(nil) == nil)
-		testutils.AssertTrue(t, WithStackTrace((*errorType)(nil)) == nil)
 	})
 	t.Run("WithMessage", func(t *testing.T) {
 		testutils.AssertTrue(t, WithMessage(nil, "new msg") == nil)
-		testutils.AssertTrue(t, WithMessage((*errorType)(nil), "new msg") == nil)
 	})
 }
 
@@ -522,11 +517,11 @@ func TestErrorFormat(t *testing.T) {
 				expect: []string{
 					"err",
 					"^github.com/secureworks/errors.TestErrorFormat$",
-					errorTestFileM(`456`),
+					errorTestFileM(`488`),
 					"^github.com/secureworks/errors.TestErrorFormat$",
-					errorTestFileM(`457`),
+					errorTestFileM(`489`),
 					"^github.com/secureworks/errors.TestErrorFormat$",
-					errorTestFileM(`458`),
+					errorTestFileM(`490`),
 				},
 			},
 		}
@@ -568,7 +563,7 @@ func TestErrorFormat(t *testing.T) {
 				expect: []string{
 					"err",
 					"^github.com/secureworks/errors.TestErrorFormat$",
-					errorTestFileM(`459`),
+					errorTestFileM(`491`),
 					`^testing\.tRunner$`,
 					`^.+/testing/testing.go:\d+$`,
 				},

--- a/examples_test.go
+++ b/examples_test.go
@@ -510,13 +510,13 @@ func ExampleNewMultiError_flattensMultiErrors() {
 	// Output: [err1; err2; err3]
 }
 
-func ExampleMultiError_Errors() {
+func ExampleMultiError_Unwrap() {
 	merr := errors.NewMultiError(
 		errors.New("err1"),
 		errors.New("err2"),
 		errors.New("err3"),
 	)
-	for _, err := range merr.Errors() {
+	for _, err := range merr.Unwrap() {
 		pprint("\n", err)
 	}
 
@@ -569,7 +569,7 @@ func ExampleMultiError_as() {
 	// To get all, you must unwrap to MultiError and then unwrap contained values.
 	var merr *errors.MultiError
 	if errors.As(err2, &merr) {
-		for i, err := range merr.Errors() {
+		for i, err := range merr.Unwrap() {
 			if errors.As(err, &unkErr) {
 				fmt.Printf("unmerged %d unwrap found: %s\n", i, unkErr.SecretValue)
 			} else {
@@ -611,7 +611,7 @@ func ExampleMultiError_is() {
 	// values.
 	var merr *errors.MultiError
 	if errors.As(err, &merr) {
-		for i, err := range merr.Errors() {
+		for i, err := range merr.Unwrap() {
 			if errors.Is(err, errSentinel) {
 				fmt.Printf("unmerged %d sentinel found: %s\n", i, err)
 			} else {

--- a/examples_test.go
+++ b/examples_test.go
@@ -676,8 +676,6 @@ func ExampleErrorsFrom() {
 		errors.New("err2"),
 		errors.New("err3"),
 	).ErrorOrNil()
-	err = fmt.Errorf("inner context: %w", err)
-	err = fmt.Errorf("outer context: %w", err)
 
 	fmt.Println(err) // Print the multierror for comparison.
 
@@ -686,7 +684,7 @@ func ExampleErrorsFrom() {
 		fmt.Println(err)
 	}
 
-	// Output: outer context: inner context: [err1; err2; err3]
+	// Output: [err1; err2; err3]
 	// err1
 	// err2
 	// err3

--- a/formatter.go
+++ b/formatter.go
@@ -1,30 +1,196 @@
 package errors
 
+// Attribution: portions of the below code and documentation are modeled
+// directly on the github.com/dominikh/go-tools/blob/master/printf
+// package, used with the permission available under the software
+// license (MIT):
+// https://github.com/dominikh/go-tools/blob/master/LICENSE
+
 import (
+	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
+	"strings"
 )
-
-var errorfFormatMatcher = regexp.MustCompile(`%(\[\d+])?w`)
 
 // Errorf is a shorthand for:
 //
-//	errors.WithFrame(fmt.Errorf("some msg: %w", err))
+//	fmt.Errorf("some msg: %w", errors.WithFrame(err))
 //
 // It is made available to support the best practice of adding a call
 // stack frame to the error context alongside a message when building a
 // chain. When possible, prefer using the full syntax instead of this
 // shorthand for clarity.
 //
-// Using an invalid format string (one that does not wrap the given
-// error) causes this method to panic.
+// Similar to fmt.Errorf, this function supports multiple `%w` verbs to
+// generate a multierror: each wrapped error will have a frame attached
+// to it.
 func Errorf(format string, values ...interface{}) error {
-	if !errorfFormatMatcher.MatchString(format) {
-		panic(NewWithStackTrace(fmt.Sprintf("invalid use of errors.Errorf: "+
-			"format string must wrap an error, but \"%%w\" not found: %q", format)))
+	verbs, err := parseFormatString(format, len(values))
+	if err != nil {
+		return errors.New(`%!e(errors.Errorf=failed: ` + err.Error() + `)`)
 	}
-	return &withFrames{
-		error:  fmt.Errorf(format, values...),
-		frames: frames{getFrame(3)},
+
+	// Interpose and wrap errors with framer if the associated verb is `%w`.
+	for _, v := range verbs {
+		if v.letter != 'w' {
+			continue
+		}
+		if wrappedErr, ok := values[v.idx].(error); ok {
+			if wrappedErr != nil {
+				values[v.idx] = &withFrames{
+					error:  wrappedErr,
+					frames: frames{getFrame(3)},
+				}
+			}
+		}
 	}
+
+	return fmt.Errorf(format, values...)
 }
+
+type fmtVerb struct {
+	letter rune
+	flags  string
+
+	// Which value in the argument list the verb uses:
+	//   * -1 denotes the next argument,
+	//   * >0 denote explicit arguments,
+	//   * 0 denotes that no argument is consumed, ie: %%. This will not be returned.
+	value int
+
+	// Similar to above: take into account argument indices used in either
+	// place. When a literal will be 0.
+	width, prec int
+
+	// The 0-indexed argument this verb is associated with.
+	idx int
+
+	raw string
+}
+
+// parseFormatString parses f and returns a list of actions.
+// An action may either be a literal string, or a Verb.
+//
+// This may break down when doing some more abstract things, like using
+// argument indices with star precisions. If there is a problem, please
+// don't use Errorf.
+func parseFormatString(f string, numValues int) (verbs []fmtVerb, err error) {
+	var nextValueIndex int
+	for len(f) > 0 {
+		if f[0] == '%' {
+			v, n, err := parseVerb(f)
+			if err != nil {
+				return nil, err
+			}
+			f = f[n:]
+			if v.value != 0 {
+				if v.width > numValues {
+					return nil, errors.New("invalid format string: not enough arguments")
+				}
+				if v.prec > numValues {
+					return nil, errors.New("invalid format string: not enough arguments")
+				}
+				if v.value == -1 {
+					v.idx = nextValueIndex
+					nextValueIndex++
+				} else {
+					// printf argument index is one-indexed, so we can always subtract 1 here.
+					v.idx = v.value - 1
+					nextValueIndex = v.value
+				}
+				if v.idx >= numValues {
+					return nil, errors.New("invalid format string: not enough arguments")
+				}
+				verbs = append(verbs, v)
+			}
+		} else {
+			n := strings.IndexByte(f, '%')
+			if n > -1 {
+				f = f[n:]
+			} else {
+				f = ""
+			}
+		}
+	}
+	return verbs, nil
+}
+
+func atoi(s string) int {
+	n, _ := strconv.Atoi(s)
+	return n
+}
+
+// parseVerb parses the verb at the beginning of f. It returns the verb,
+// how much of the input was consumed, and an error, if any.
+func parseVerb(f string) (fmtVerb, int, error) {
+	if len(f) < 2 {
+		return fmtVerb{}, 0, errors.New("invalid format string")
+	}
+	const (
+		flags      = 1
+		widthStar  = 3
+		widthIndex = 5
+		dot        = 6
+		precStar   = 8
+		precIndex  = 10
+		verbIndex  = 11
+		verb       = 12
+	)
+
+	m := re.FindStringSubmatch(f)
+	if m == nil {
+		return fmtVerb{}, 0, errors.New("invalid format string")
+	}
+
+	v := fmtVerb{
+		letter: []rune(m[verb])[0],
+		flags:  m[flags],
+		raw:    m[0],
+	}
+
+	if m[widthStar] != "" {
+		if m[widthIndex] != "" {
+			v.width = atoi(m[widthIndex])
+		} else {
+			v.width = -1
+		}
+	}
+
+	if m[dot] != "" && m[precStar] != "" {
+		if m[precIndex] != "" {
+			v.prec = atoi(m[precIndex])
+		} else {
+			v.prec = -1
+		}
+	}
+
+	if m[verb] == "%" {
+		v.value = 0
+	} else if m[verbIndex] != "" {
+		idx := atoi(m[verbIndex])
+		if idx <= 0 || idx > 128 {
+			return fmtVerb{}, 0, errors.New("invalid format string: bad argument index")
+		}
+		v.value = idx
+	} else {
+		v.value = -1
+	}
+
+	return v, len(m[0]), nil
+}
+
+const (
+	flags             = `([+#0 -]*)`
+	verb              = `([a-zA-Z%])`
+	index             = `(?:\[([0-9]+)\])`
+	star              = `((` + index + `)?\*)`
+	width1            = `([0-9]+)`
+	width2            = star
+	width             = `(?:` + width1 + `|` + width2 + `)`
+	precision         = width
+	widthAndPrecision = `(?:(?:` + width + `)?(?:(\.)(?:` + precision + `)?)?)`
+)
+
+var re = regexp.MustCompile(`^%` + flags + widthAndPrecision + `?` + index + `?` + verb)

--- a/formatter.go
+++ b/formatter.go
@@ -1,0 +1,30 @@
+package errors
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var errorfFormatMatcher = regexp.MustCompile(`%(\[\d+])?w`)
+
+// Errorf is a shorthand for:
+//
+//	errors.WithFrame(fmt.Errorf("some msg: %w", err))
+//
+// It is made available to support the best practice of adding a call
+// stack frame to the error context alongside a message when building a
+// chain. When possible, prefer using the full syntax instead of this
+// shorthand for clarity.
+//
+// Using an invalid format string (one that does not wrap the given
+// error) causes this method to panic.
+func Errorf(format string, values ...interface{}) error {
+	if !errorfFormatMatcher.MatchString(format) {
+		panic(NewWithStackTrace(fmt.Sprintf("invalid use of errors.Errorf: "+
+			"format string must wrap an error, but \"%%w\" not found: %q", format)))
+	}
+	return &withFrames{
+		error:  fmt.Errorf(format, values...),
+		frames: frames{getFrame(3)},
+	}
+}

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -1,25 +1,25 @@
 package errors
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/secureworks/errors/internal/testutils"
 )
 
-func TestErrorf(t *testing.T) {
+func TestErrorf_singleError(t *testing.T) {
 	t.Run("wraps with message context", func(t *testing.T) {
 		err := Errorf("wraps: %w", newErrorCaller())
 		testutils.AssertEqual(t, `wraps: new err`, fmt.Sprint(err))
 	})
 
-	t.Run("wraps with frame context", func(t *testing.T) {
+	t.Run("includes frame data", func(t *testing.T) {
 		err := Errorf("wraps: %w", newErrorCaller())
-		withFrames, ok := err.(interface{ Frames() Frames })
-		testutils.AssertTrue(t, ok)
-		testutils.AssertLinesMatch(t, withFrames.Frames(), "%+v", []string{
+		ff := FramesFrom(err)
+		testutils.AssertLinesMatch(t, ff, "%+v", []string{
 			"",
-			"^github.com/secureworks/errors\\.TestErrorf.func2$",
+			"^github.com/secureworks/errors\\.TestErrorf_singleError.func2$",
 			"^\t.+/formatter_test\\.go:\\d+$",
 		})
 	})
@@ -27,7 +27,278 @@ func TestErrorf(t *testing.T) {
 	t.Run("handles variant params", func(t *testing.T) {
 		err := Errorf("wraps: %[2]s (%[3]d): %[1]w", newErrorCaller(), "inner", 1)
 		testutils.AssertErrorMessage(t, "wraps: inner (1): new err", err)
-		_, ok := err.(interface{ Frames() Frames })
-		testutils.AssertTrue(t, ok)
+		ff := FramesFrom(err)
+		testutils.AssertLinesMatch(t, ff, "%+v", []string{
+			"",
+			"^github.com/secureworks/errors\\.TestErrorf_singleError.func3$",
+			"^\t.+/formatter_test\\.go:\\d+$",
+		})
 	})
+}
+
+func TestErrorf_multiError(t *testing.T) {
+	errSignal := errors.New("signal")
+	ctxErr := errors.New("just context")
+	err := Errorf("outer: %w: %v: %w", errSignal, ctxErr, newErrorCaller())
+
+	testutils.AssertEqual(t, `outer: signal: just context: new err`, fmt.Sprint(err))
+	testutils.AssertTrue(t, Is(err, errSignal))
+
+	errs := ErrorsFrom(err)
+	testutils.AssertEqual(t, 2, len(errs))
+
+	// Err 1
+	testutils.AssertTrue(t, Is(errs[0], errSignal))
+	ff := FramesFrom(errs[0])
+	testutils.AssertLinesMatch(t, ff, "%+v", []string{
+		"",
+		"^github.com/secureworks/errors\\.TestErrorf_multiError$",
+		"^\t.+/formatter_test\\.go:\\d+$",
+	})
+
+	// Err 2
+	testutils.AssertEqual(t, "new err", errs[1].Error())
+	ff = FramesFrom(errs[1])
+	testutils.AssertLinesMatch(t, ff, "%+v", []string{
+		"",
+		"^github.com/secureworks/errors\\.TestErrorf_multiError$",
+		"^\t.+/formatter_test\\.go:\\d+$",
+	})
+}
+
+func Benchmark_parseVerb(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		parseVerb("%[3]*.[2]*[1]f")
+	}
+}
+
+func Test_parseVerb(t *testing.T) {
+	var cases = []struct {
+		in  string
+		out fmtVerb
+	}{
+		{
+			`%d`,
+			fmtVerb{
+				letter: 'd',
+				value:  -1,
+			},
+		},
+		{
+			`%#d`,
+			fmtVerb{
+				letter: 'd',
+				flags:  "#",
+				value:  -1,
+			},
+		},
+		{
+			`%+#d`,
+			fmtVerb{
+				letter: 'd',
+				flags:  "+#",
+				value:  -1,
+			},
+		},
+		{
+			`%[2]d`,
+			fmtVerb{
+				letter: 'd',
+				value:  2,
+			},
+		},
+		{
+			`%[3]*.[2]*[1]f`,
+			fmtVerb{
+				letter: 'f',
+				value:  1,
+				prec:   2,
+				width:  3,
+			},
+		},
+		{
+			`%6.2f`,
+			fmtVerb{
+				letter: 'f',
+				value:  -1,
+			},
+		},
+		{
+			`%#[1]x`,
+			fmtVerb{
+				letter: 'x',
+				flags:  "#",
+				value:  1,
+			},
+		},
+		{
+			"%%",
+			fmtVerb{
+				letter: '%',
+				value:  0,
+			},
+		},
+		{
+			"%*%",
+			fmtVerb{
+				letter: '%',
+				value:  0,
+				width:  -1,
+			},
+		},
+		{
+			"%[1]%",
+			fmtVerb{
+				letter: '%',
+				value:  0,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("parseVerb(%q)", tc.in), func(t *testing.T) {
+			tc.out.raw = tc.in
+			v, n, err := parseVerb(tc.in)
+			if err != nil {
+				t.Errorf("unexpected error %s while parsing %s", err, tc.in)
+			}
+			if n != len(tc.in) {
+				t.Errorf("parseVerb only consumed %d of %d bytes", n, len(tc.in))
+			}
+			if v != tc.out {
+				t.Errorf("%s parsed to %#v, want %#v", tc.in, v, tc.out)
+			}
+		})
+	}
+}
+
+func Test_parseFormatString(t *testing.T) {
+	d := func(raw string, value, idx int) fmtVerb {
+		return fmtVerb{
+			letter: 'd',
+			value:  value,
+			idx:    idx,
+			raw:    raw,
+		}
+	}
+
+	var cases = []struct {
+		str string
+		num int
+		out []fmtVerb
+		err error
+	}{
+		{
+			str: `%d`,
+			num: 1,
+			out: []fmtVerb{d("%d", -1, 0)},
+		},
+		{
+			str: `%d`,
+			num: 5,
+			out: []fmtVerb{d("%d", -1, 0)},
+		},
+		{
+			str: `%[3]d`,
+			num: 5,
+			out: []fmtVerb{d("%[3]d", 3, 2)},
+		},
+		{
+			str: `%[0]d`,
+			num: 1,
+			err: errors.New("invalid format string: bad argument index"),
+		},
+		{
+			str: `%[6]d`,
+			num: 5,
+			err: errors.New("invalid format string: not enough arguments"),
+		},
+		{
+			str: `%d`,
+			num: 0,
+			err: errors.New("invalid format string: not enough arguments"),
+		},
+		{
+			str: `%d %d %d %d`,
+			num: 4,
+			out: []fmtVerb{
+				d("%d", -1, 0),
+				d("%d", -1, 1),
+				d("%d", -1, 2),
+				d("%d", -1, 3),
+			},
+		},
+		{
+			str: `%[2]d %d %d`,
+			num: 4,
+			out: []fmtVerb{
+				d("%[2]d", 2, 1),
+				d("%d", -1, 2),
+				d("%d", -1, 3),
+			},
+		},
+		{
+			str: `%[2]d %d %d`,
+			num: 3,
+			err: errors.New("invalid format string: not enough arguments"),
+		},
+		{
+			str: `%d %d %d %[1]d %d %d`,
+			num: 3,
+			out: []fmtVerb{
+				d("%d", -1, 0),
+				d("%d", -1, 1),
+				d("%d", -1, 2),
+				d("%[1]d", 1, 0),
+				d("%d", -1, 1),
+				d("%d", -1, 2),
+			},
+		},
+		{
+			str: `%[3]*.[2]*[1]d %d`,
+			num: 3,
+			out: []fmtVerb{
+				{
+					letter: 'd',
+					width:  3,
+					prec:   2,
+					value:  1,
+					idx:    0,
+					raw:    "%[3]*.[2]*[1]d",
+				},
+				d("%d", -1, 1),
+			},
+		},
+		{
+			str: `%[3]*.[2]*[1]d %d`,
+			num: 2,
+			err: errors.New("invalid format string: not enough arguments"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("parseFormatString(%q,%d)", tc.str, tc.num), func(t *testing.T) {
+			verbs, err := parseFormatString(tc.str, tc.num)
+			if tc.err != nil {
+				if err == nil {
+					t.Fatalf("did not return an error")
+				} else if err.Error() != tc.err.Error() {
+					t.Fatalf("returned an unexpected error: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("returned an unexpected error: %v", err)
+				return
+			}
+			if len(verbs) != len(tc.out) {
+				t.Fatalf("returned %d verbs, want %d", len(verbs), len(tc.out))
+				return
+			}
+			for i, v := range verbs {
+				if v != tc.out[i] {
+					t.Fatalf("returned %#v, want %#v", v, tc.out[i])
+				}
+			}
+		})
+	}
 }

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -20,7 +20,7 @@ func TestErrorf(t *testing.T) {
 		testutils.AssertLinesMatch(t, withFrames.Frames(), "%+v", []string{
 			"",
 			"^github.com/secureworks/errors\\.TestErrorf.func2$",
-			"^\t.+/format_test\\.go:\\d+$",
+			"^\t.+/formatter_test\\.go:\\d+$",
 		})
 	})
 

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -1,0 +1,33 @@
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/secureworks/errors/internal/testutils"
+)
+
+func TestErrorf(t *testing.T) {
+	t.Run("wraps with message context", func(t *testing.T) {
+		err := Errorf("wraps: %w", newErrorCaller())
+		testutils.AssertEqual(t, `wraps: new err`, fmt.Sprint(err))
+	})
+
+	t.Run("wraps with frame context", func(t *testing.T) {
+		err := Errorf("wraps: %w", newErrorCaller())
+		withFrames, ok := err.(interface{ Frames() Frames })
+		testutils.AssertTrue(t, ok)
+		testutils.AssertLinesMatch(t, withFrames.Frames(), "%+v", []string{
+			"",
+			"^github.com/secureworks/errors\\.TestErrorf.func2$",
+			"^\t.+/format_test\\.go:\\d+$",
+		})
+	})
+
+	t.Run("handles variant params", func(t *testing.T) {
+		err := Errorf("wraps: %[2]s (%[3]d): %[1]w", newErrorCaller(), "inner", 1)
+		testutils.AssertErrorMessage(t, "wraps: inner (1): new err", err)
+		_, ok := err.(interface{ Frames() Frames })
+		testutils.AssertTrue(t, ok)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/secureworks/errors
 
-go 1.13
+go 1.20

--- a/internal/constraints/constraints.go
+++ b/internal/constraints/constraints.go
@@ -5,7 +5,7 @@ package constraints
 
 var (
 	// Only available when on Go v1.13 or more.
-	_ = Go113
+	_ = Go120
 
 	// Only available on 64-bit architectures.
 	_ = GoArch64

--- a/internal/constraints/go120.go
+++ b/internal/constraints/go120.go
@@ -1,0 +1,6 @@
+//go:build go1.20
+// +build go1.20
+
+package constraints
+
+const Go120 = uint8(0)

--- a/multierror.go
+++ b/multierror.go
@@ -12,30 +12,30 @@ import (
 )
 
 // MultiError is a list of errors. For compatibility, this type also
-// implements the standard library error interfaces (including Unwrap,
-// and the unexported interfaces for As, and Is) and includes helpers
-// for managing groups of errors using Go patterns.
+// implements the standard library error interfaces (including
+// Unwrap() []error, the unexported interfaces for As, and Is) and
+// includes helpers for managing groups of errors using Go patterns.
 //
 // MultiErrors are guaranteed to be flat: no errors contained in its
 // list are (or wrap) a MultiError. The MultiError pattern is for
-// top-level collection of error groups only. MultiErrors may not
-// themselves (since they implement the error interface) wrap another
-// error, so Unwrap always returns nil.
+// top-level collection of error groups only (a major difference with
+// the standard library implementation, which can effectively store
+// errors as a tree).
 //
 // MultiErrors are not synchronized: you must handle them in a
 // concurrency safe way when accessing from multiple goroutines.
 //
 // Unlike some error collection / multiple-error packages, we rely on an
-// exported MultiError type make it obvious how they should be handled
-// in the codebase. While they can be treated as errors when necessary,
-// we must be vigilant about nil-checking with MultiError:
+// exported MultiError type make it obvious how it should be handled in
+// the codebase. While it can be treated as an error when necessary, we
+// must be vigilant about nil-checking with MultiError:
 //
 //	if merr := errors.NewMultiError(nil); merr != nil {
 //		// This will always be true!
 //	}
 //
 //	// Instead, check the length of the errors:
-//	if merr := errors.NewMultiError(nil); merr.Len() > 0 {
+//	if merr := errors.NewMultiError(nil); len(merr.Unwrap()) > 0 {
 //		// This works ...
 //	}
 //
@@ -50,8 +50,8 @@ import (
 // Any package function that expects a multiple error implementation
 // relies on the unexported interface:
 //
-//	type multiError interface {
-//		Errors() []error
+//	type multierror interface {
+//		Unwrap() []error
 //	}
 //
 // This is for simplicity and interoperability: you can still extract
@@ -61,17 +61,17 @@ type MultiError struct {
 }
 
 // A simple interface for identifying an error wrapper for multiple
-// errors (including MultiError).
-type multiError interface {
-	Errors() []error
+// errors (including MultiError). This is the [standard interface] as
+// defined in Go.
+//
+// [standard interface]: https://pkg.go.dev/errors@go1.20#pkg-overview
+type multierror interface {
+	Unwrap() []error
 }
 
 var _ interface { // Assert interface implementation.
 	error
-	multiError
-	Unwrap() error
-	As(interface{}) bool
-	Is(error) bool
+	multierror
 	fmt.Formatter
 } = (*MultiError)(nil)
 
@@ -102,24 +102,32 @@ func (merr *MultiError) Error() string {
 	return buf.String()
 }
 
-// Errors returns the underlying value of the MultiError: a slice of
-// errors. It is how we extract the underlying errors. Returns a nil
-// slice if the error is nil or has no errors.
+// Unwrap returns the underlying value of the MultiError: a slice of
+// errors. It returns a nil slice if the error is nil or has no errors.
 //
-// This interface may be used to treat MultiErrors as an interface for
-// use in code that may not want to expect a MultiError type directly:
+// This interface may be used to handle multierrors in code that may not
+// want to expect a MultiError type directly:
 //
-//	if merr, ok := err.(interface{ Errors() [] error }); ok {
+//	if merr, ok := err.(interface{ Unwrap() [] error }); ok {
 //		// ...
 //	}
 //
 // Do not modify the returned errors and expect the MultiError to remain
 // stable.
-func (merr *MultiError) Errors() []error {
+func (merr *MultiError) Unwrap() []error {
 	if len(merr.errors) == 0 {
 		return nil
 	}
 	return merr.errors
+}
+
+// Errors is the version v0.1 interface for multierrors. This pre-dated
+// the release of Go 1.20, so Unwrap() []error was not a clear standard
+// yet. It now is.
+//
+// Deprecated: use Unwrap instead.
+func (merr *MultiError) Errors() []error {
+	return merr.Unwrap()
 }
 
 // ErrorOrNil is used to get a clean error interface for reflection. If
@@ -134,10 +142,10 @@ func (merr *MultiError) Errors() []error {
 //	newMErr := errors.NewMultiError(err)
 //	newMErr.Errors() // => []error{e1, e2, e3}
 func (merr *MultiError) ErrorOrNil() error {
-	if len(merr.Errors()) == 0 {
+	if len(merr.Unwrap()) == 0 {
 		return nil
 	}
-	if len(merr.Errors()) == 1 {
+	if len(merr.Unwrap()) == 1 {
 		return merr.errors[0]
 	}
 	return merr
@@ -160,15 +168,15 @@ func (merr *MultiError) Append(errs ...error) {
 	}
 }
 
-// flatten gets a list of errors from a multiError that is certain not
-// to contain any other multiErrors or wrapped multiErrors.
-func flatten(m multiError) (errs []error) {
+// flatten gets a list of errors from a multierror that is certain not
+// to contain any other multierrors or wrapped multierrors.
+func flatten(m multierror) (errs []error) {
 	// We can skip a deep unwrap/flatten pass on a MultiError.
 	if merr, ok := m.(*MultiError); ok {
-		return merr.Errors()
+		return merr.Unwrap()
 	}
 
-	for _, err := range m.Errors() {
+	for _, err := range m.Unwrap() {
 		if err == nil {
 			continue
 		}
@@ -181,46 +189,14 @@ func flatten(m multiError) (errs []error) {
 	return
 }
 
-// unwrapMultiErr finds the first multiError in the error chain. If none
+// unwrapMultiErr finds the first multierror in the error chain. If none
 // is found it returns nil.
-func unwrapMultiErr(err error) multiError {
-	merr := new(multiError)
+func unwrapMultiErr(err error) multierror {
+	merr := new(multierror)
 	if As(err, merr) {
 		return *merr
 	}
 	return nil
-}
-
-// Unwrap implements the error Unwrap interface. It always returns nil
-// since a MultiError may not wrap another error. The errors in a
-// MultiError may be able to be Unwrapped, however.
-func (merr *MultiError) Unwrap() error { return nil }
-
-// As finds the first error that matches target, and if so, sets target
-// to that error value and returns true. Otherwise, it returns false.
-//
-// This function allows As to traverse the values stored on the
-// MultiError, even though the type has a null Unwrap implementation.
-func (merr *MultiError) As(target interface{}) bool {
-	for _, err := range merr.Errors() {
-		if As(err, target) {
-			return true
-		}
-	}
-	return false
-}
-
-// Is reports whether any error matches target.
-//
-// This function allows Is to traverse the values stored on the
-// MultiError, even though the type has a null Unwrap implementation.
-func (merr *MultiError) Is(target error) bool {
-	for _, err := range merr.Errors() {
-		if Is(err, target) {
-			return true
-		}
-	}
-	return false
 }
 
 func (merr *MultiError) Format(s fmt.State, verb rune) {
@@ -228,7 +204,7 @@ func (merr *MultiError) Format(s fmt.State, verb rune) {
 	case 'v':
 		switch {
 		case s.Flag('+'):
-			size := len(merr.Errors())
+			size := len(merr.Unwrap())
 			if size < 1 {
 				io.WriteString(s, "empty errors: []")
 				return
@@ -259,10 +235,10 @@ func (merr *MultiError) Format(s fmt.State, verb rune) {
 	}
 }
 
-func formatMessages(w io.Writer, merr multiError, delimiters [2]string) {
+func formatMessages(w io.Writer, merr multierror, delimiters [2]string) {
 	first := true
 	io.WriteString(w, delimiters[0])
-	for _, err := range merr.Errors() {
+	for _, err := range merr.Unwrap() {
 		if !first {
 			io.WriteString(w, "; ")
 		}
@@ -273,8 +249,8 @@ func formatMessages(w io.Writer, merr multiError, delimiters [2]string) {
 }
 
 // ErrorsFrom returns a list of errors that the supplied error is
-// composed of. multiErrors are unwrapped, flattened, and returned. If
-// the error is nil, or is a multiError with no errors, a nil slice is
+// composed of. multierrors are unwrapped, flattened, and returned. If
+// the error is nil, or is a multierror with no errors, a nil slice is
 // returned. It is useful when an API has forced a MultiError to be
 // returned as an error type, or when it is unknown if a given error is
 // a MultiError or not:
@@ -294,7 +270,7 @@ func ErrorsFrom(err error) []error {
 		return nil
 	}
 	if merr, ok := err.(*MultiError); ok {
-		errs := merr.Errors()
+		errs := merr.Unwrap()
 		if len(errs) == 0 {
 			return nil
 		}
@@ -314,11 +290,10 @@ func ErrorsFrom(err error) []error {
 	return []error{err}
 }
 
-// Append is a version of NewMultiError optimized for the most common
-// case of appending errors: two errors where the first may be a
-// multiError but the second definitely is not. If you pass a multiError
-// as the second error Append will ignore it and add a new, specific
-// error to the returned error (which is implemented by MultiError).
+// Append is a version of NewMultiError optimized for the common case of
+// merging a small group of errors and expecting the outcome to be an
+// error or nil, akin to the standard library's errors.Join (and it is,
+// in fact, used for this library's implementation of Join).
 //
 // The following pattern may also be used to record failure of deferred
 // operations without losing information about the original error.
@@ -328,37 +303,24 @@ func ErrorsFrom(err error) []error {
 //		defer func() {
 //			err = errors.Append(err, f.Close())
 //		}()
-//
-// QUESTION(PH): should we panic instead of add error?
-func Append(receivingErr error, appendingErr error) error {
-	receivingErrIsNil := receivingErr == nil
-	appendingErrIsNil := appendingErr == nil
-	if receivingErrIsNil && appendingErrIsNil {
+func Append(errs ...error) error {
+	if len(errs) == 0 {
 		return nil
 	}
 
-	switch {
-	case receivingErrIsNil:
-		if mAppendingErr := unwrapMultiErr(appendingErr); mAppendingErr != nil {
-			appendingErr = New("errors.Append used incorrectly: " +
-				"second parameter may not be a multiError")
-		}
-		return (&MultiError{errors: []error{appendingErr}}).ErrorOrNil()
-	case appendingErrIsNil:
-		if mReceivingErr := unwrapMultiErr(receivingErr); mReceivingErr != nil {
-			return &MultiError{errors: flatten(mReceivingErr)}
-		}
-		return (&MultiError{errors: []error{receivingErr}}).ErrorOrNil()
-	default:
-		if mAppendingErr := unwrapMultiErr(appendingErr); mAppendingErr != nil {
-			appendingErr = New("errors.Append used incorrectly: " +
-				"second parameter may not be a multiError")
-		}
-		if mReceivingErr := unwrapMultiErr(receivingErr); mReceivingErr != nil {
-			return &MultiError{errors: append(flatten(mReceivingErr), appendingErr)}
-		}
-		return (&MultiError{errors: []error{receivingErr, appendingErr}}).ErrorOrNil()
+	// Optimized cases: 1 or 2 errors.
+	if len(errs) == 1 {
+		return errs[0]
 	}
+	if len(errs) == 2 && errs[0] == nil {
+		return errs[1]
+	}
+	if len(errs) == 2 && errs[1] == nil {
+		return errs[0]
+	}
+
+	// Do the work.
+	return NewMultiError(errs...).ErrorOrNil()
 }
 
 // AppendInto appends an error into the destination of an error pointer
@@ -370,7 +332,7 @@ func Append(receivingErr error, appendingErr error) error {
 //
 // The above is equivalent to,
 //
-//	err := errors.Append(r.Close(), w.Close()).ErrorOrNil()
+//	err := errors.Append(r.Close(), w.Close())
 //
 // As AppendInto reports whether the provided error was non-nil, it may
 // be used to build an errors error in a loop more ergonomically. For
@@ -387,47 +349,21 @@ func Append(receivingErr error, appendingErr error) error {
 //	if err != nil {
 //		log.Fatal(err)
 //	}
-//
-// Compare this with a version that relies solely on Append:
-//
-//	var err error
-//	for line := range lines {
-//		var item Item
-//		if parseErr := parse(line, &item); parseErr != nil {
-//			err = errors.Append(err, parseErr)
-//			continue
-//		}
-//		items = append(items, item)
-//	}
-//	if err != nil {
-//		log.Fatal(err)
-//	}
-//
-// As in Append, if you pass a multiError as the second error AppendInto
-// will ignore it and add a new, specific error to the returned
-// MultiError.
-//
-// QUESTION(PH): should we panic instead of add error?
 func AppendInto(receivingErr *error, appendingErr error) bool {
-	switch {
-	case receivingErr == nil:
+	if receivingErr == nil {
 		// We panic if 'into' is nil. This is not documented above
 		// because suggesting that the pointer must be non-nil may
 		// confuse users into thinking that the error that it points
 		// to must be non-nil.
 		panic(NewWithStackTrace(
 			"errors.AppendInto used incorrectly: receiving pointer must not be nil"))
-	case appendingErr == nil:
-		*receivingErr = NewMultiError(*receivingErr).ErrorOrNil()
-		return false
-	default:
-		if mm := unwrapMultiErr(appendingErr); mm != nil {
-			appendingErr = New("errors.AppendInto used incorrectly: " +
-				"second parameter may not be a multiError")
-		}
-		*receivingErr = Append(*receivingErr, appendingErr)
-		return true
 	}
+
+	if appendingErr == nil {
+		return false
+	}
+	*receivingErr = Append(*receivingErr, appendingErr)
+	return true
 }
 
 // ErrorResulter is a function that may fail with an error. Use it with

--- a/stdlib.go
+++ b/stdlib.go
@@ -49,3 +49,16 @@ func Is(err, target error) bool { return stderrors.Is(err, target) }
 // As panics if target is not a non-nil pointer to either a type that implements
 // error, or to any interface type.
 func As(err error, target interface{}) bool { return stderrors.As(err, target) }
+
+// Join returns an error that wraps the given errors. Any nil error
+// values are discarded. Join returns nil if every value in errs is nil.
+// The error formats as the concatenation of the strings obtained by
+// calling the Error method of each element of errs.
+//
+// A non-nil error returned by Join implements the Unwrap() []error
+// method.
+//
+// Since you are using the github.com/secureworks/errors package, be
+// aware that this returns a MultiError instead of the default standard
+// library's implementation.
+func Join(errs ...error) error { return Append(errs...) }

--- a/stdlib_test.go
+++ b/stdlib_test.go
@@ -24,65 +24,6 @@ func TestNew(t *testing.T) {
 	testutils.AssertEqual(t, stdErr.Error(), libErr.Error())
 }
 
-func TestNewWith(t *testing.T) {
-	cases := []struct {
-		name string
-		err  error
-		wrap bool
-		impl []reflect.Type
-	}{
-		{
-			name: "Stack",
-			err:  NewWithStackTrace("new err"),
-			wrap: true,
-			impl: []reflect.Type{
-				stackFramerIface,
-				stackTracerIface,
-			},
-		},
-		{
-			name: "Frame",
-			err:  NewWithFrame("new err"),
-			wrap: true,
-			impl: []reflect.Type{
-				stackFramerIface,
-			},
-		},
-		{
-			name: "FrameAt",
-			err:  NewWithFrameAt("new err", 0),
-			wrap: true,
-			impl: []reflect.Type{
-				stackFramerIface,
-			},
-		},
-		{
-			name: "Frames",
-			err:  NewWithFrames("new err", Frames{}),
-			wrap: true,
-			impl: []reflect.Type{
-				stackFramerIface,
-			},
-		},
-	}
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			// Unwraps.
-			baseErr := Unwrap(tt.err)
-			if tt.wrap {
-				testutils.AssertEqual(t, "new err", baseErr.Error())
-			} else {
-				testutils.AssertNil(t, baseErr)
-			}
-
-			// Implements.
-			for _, iface := range tt.impl {
-				testutils.AssertTrue(t, reflect.TypeOf(tt.err).Implements(iface))
-			}
-		})
-	}
-}
-
 func TestUnwrap(t *testing.T) {
 	err := New("new err")
 

--- a/stdlib_test.go
+++ b/stdlib_test.go
@@ -239,7 +239,7 @@ func TestJoin(t *testing.T) {
 	errs := []error{err1, err2, nil, err3}
 
 	merr := Join(errs...)
-	testutils.AssertEqual(t, "new err 1; new err 2; new err 3", merr.Error())
+	testutils.AssertEqual(t, "[new err 1; new err 2; new err 3]", merr.Error())
 	testutils.AssertEqual(t, []error{err1, err2, err3}, merr.(interface{ Unwrap() []error }).Unwrap())
 	testutils.AssertNil(t, Join(nil, nil, nil))
 }

--- a/stdlib_test.go
+++ b/stdlib_test.go
@@ -3,7 +3,6 @@ package errors
 import (
 	stderrors "errors"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/secureworks/errors/internal/testutils"
@@ -75,6 +74,7 @@ func TestUnwrap(t *testing.T) {
 
 func TestIs(t *testing.T) {
 	err := New("new err")
+	err2 := New("signal error")
 
 	type args struct {
 		err    error
@@ -133,6 +133,14 @@ func TestIs(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "std errors multierror compatibility",
+			args: args{
+				err:    fmt.Errorf("wrap: %w; %w", err, err2),
+				target: err2,
+			},
+			want: true,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -143,6 +151,7 @@ func TestIs(t *testing.T) {
 
 func TestAs(t *testing.T) {
 	err := customErr{msg: "test message"}
+	err2 := New("signal error")
 
 	type args struct {
 		err    error
@@ -201,6 +210,14 @@ func TestAs(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "std errors multierror compatibility",
+			args: args{
+				err:    fmt.Errorf("wrap: %w; %w", err, err2),
+				target: new(customErr),
+			},
+			want: true,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -213,4 +230,16 @@ func TestAs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestJoin(t *testing.T) {
+	err1 := New("new err 1")
+	err2 := New("new err 2")
+	err3 := New("new err 3")
+	errs := []error{err1, err2, nil, err3}
+
+	merr := Join(errs...)
+	testutils.AssertEqual(t, "new err 1; new err 2; new err 3", merr.Error())
+	testutils.AssertEqual(t, []error{err1, err2, err3}, merr.(interface{ Unwrap() []error }).Unwrap())
+	testutils.AssertNil(t, Join(nil, nil, nil))
 }

--- a/syncerr/docs.go
+++ b/syncerr/docs.go
@@ -51,7 +51,7 @@
 //	// ...
 //	err := group.Wait()
 //	merr, _ := err.(*errors.MultiError)
-//	fmt.Println(merr.Errors())
+//	fmt.Println(merr.Unwrap())
 //
 // ParallelGroup includes the function WaitForMultiError that skips the
 // step of asserting the multierror interface on the result:
@@ -60,5 +60,5 @@
 //	group.Go(taskRunner, "task", "1")
 //	// ...
 //	merr := group.WaitForMultiError()
-//	fmt.Println(merr.Errors())
+//	fmt.Println(merr.Unwrap())
 package syncerr

--- a/syncerr/example_parallel_group_test.go
+++ b/syncerr/example_parallel_group_test.go
@@ -34,7 +34,7 @@ func Example_parallelGroup() {
 	fmt.Println()
 	fmt.Println()
 
-	for _, err := range merr.Errors() {
+	for _, err := range merr.Unwrap() {
 		fmt.Println(err)
 	}
 

--- a/syncerr/syncerr_test.go
+++ b/syncerr/syncerr_test.go
@@ -127,7 +127,7 @@ func TestParallelGroup(t *testing.T) {
 
 		merr := group.WaitForMultiError()
 		expected := sortedMessages(taskErrors)
-		actual := sortedMessages(merr.Errors())
+		actual := sortedMessages(merr.Unwrap())
 		testutils.AssertEqual(t,
 			expected, actual, fmt.Sprintf("case %d: expected errors", i))
 	}
@@ -160,7 +160,7 @@ func TestParallelGroup_WrapName(t *testing.T) {
 
 	merr := group.WaitForMultiError()
 	testutils.AssertEqual(t,
-		[]string{"worker 0: new err: 1", "worker 3: new err: 2"}, sortedMessages(merr.Errors()))
+		[]string{"worker 0: new err: 1", "worker 3: new err: 2"}, sortedMessages(merr.Unwrap()))
 }
 
 func sortedMessages(errs []error) (msgs []string) {


### PR DESCRIPTION
This PR updates the library to be compatible with the standard library's approach to handling multiple errors introduced in Go v1.20. It:

- updates the minimum Go version constraint to v1.20 and supports Go's new multierror standard;
  - includes the "pass-thru" logic for `errors.Join`;
  - updates the "multierror" interface that triggers multierror handling to be `Unwrap() []error` instead of `Errors() []error`;
  - updates `errors.Errorf` to work similarly to the updates in Go v1.20 for `fmt.Errorf`;
  - simplifies `MultiError` so that it works more like the standard library implementation, removing some abilities;
- makes the `errors.Append` and `errors.AppendInto` tools work more simply and reliably; 
- updates the documentation to align with all of this.

This all is a breaking change: good thing we aren't at v1.0 yet.

Important points are below:

### `Unwrap() []error`

The single biggest change: we use the unexported interface `Unwrap() []error` to signal an error is a "multierror," ie a collection of errors. This is similar to the `Errors() []error` interface in v0.1, so it's mostly just swapped out in places. However, it's adoption by the standard library now means:

1. we can drop our specific implementations of `MultiError.As` and `MultiError.Is` that crawled the entirety of a `MultiError`;
2. we can ignore other errors libraries multierror interfaces, and just assume this is the standard we want to accept.

### Remove multierror "recursive flattening"

Recursive flattening, or walking through a multierror's tree and extracting each leaf error and flattening it into a single list, was a basic part of the `MultiError` in v0.1 of the library, and that is removed. It was removed because:

1. it had the effect of "losing context," that is dropping layers of wrapping around nested errors that may have carried important information for error handling or debugging;
2. Go 1.20 `errors.As` and `errors.Is` now work with multierrors that implement `Unwrap() []error` correctly, so they walk the entire tree, obviating most of the need;
3. it was difficult to manage and test.

This also means we no longer recursively attempt to pull out nested errors when we use `errors.ErrorsFrom`: retaining this meant a lot of overhead (and the above "lost context" issue) for very little payoff. Users should be thinking of "joining errors" more as a top-level solution, and will ideally avoid wrapping them (see the updated approach to `errors.Errorf`).

However, one big feature of using our `MultiError` implementation and tooling is that we do still flatten multierrors directly passed as errors, which allow us to progressively build up a multierror using `errors.Append`, for example, and then `errors.ErrorsFrom` will return _all_ of the coalesced errors, not just the most recently joined one.

### `errors.Errorf` returns an "unwrapped" result

Following the updated approach that the standard library used with `fmt.Errorf`, `errors.Errorf` now supports multiple errors. Additionally, it now wraps the error with frames _before_ it is wrapped into the context. That means that we can use `errors.ErrorsFrom` on the result and _each_ returned error will retain all the expected frames when we call `errors.FramesFrom`.

### Appending

Finally, we change `errors.Append` to work pretty much the same as one would expect of `errors.Join`, but again it does the single-level flattening for progressive coalescing of errors. `errors.AppendInto` follows suit.

We also remove the short-lived `MultiError.Append` method introduced in the last PR since it made `MultiError` mutable, and therefore introduced a range of problems. Instead, users should stick to using `errors.Append` for progressive generation.